### PR TITLE
Update dnsmasq.yml

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -36,11 +36,11 @@
     mode: "0644"
   become: true
   notify: restart dnsmasq
-  when: "{{ dnsmasq_item.when }}"
+  when: dnsmasq_item.when
   tags: dnsmasq
   loop:
-    - { dest: /etc/dnsmasq.d/10-consul, group: root, when: ansible_os_family|lower != "freebsd" }
-    - { dest: /usr/local/etc/dnsmasq.d/consul.conf, group: wheel, when: ansible_os_family|lower == "freebsd" }
+    - { dest: /etc/dnsmasq.d/10-consul, group: root, when: '{{ ansible_os_family|lower != "freebsd" }}' }
+    - { dest: /usr/local/etc/dnsmasq.d/consul.conf, group: wheel, when: '{{ ansible_os_family|lower == "freebsd" }}' }
   loop_control:
     loop_var: dnsmasq_item
 


### PR DESCRIPTION
Avoid warning:

```
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ dnsmasq_item.when }}
```